### PR TITLE
Better thread handling

### DIFF
--- a/src/main/java/moe/wolfgirl/probejs/ProbeDump.java
+++ b/src/main/java/moe/wolfgirl/probejs/ProbeDump.java
@@ -130,7 +130,8 @@ public class ProbeDump {
                     report(Component.translatable("probejs.dump.dump_error", scriptDump.manager.scriptType.toString()).kjs$red());
                     throw new RuntimeException(e);
                 }
-            });
+            },
+            "ProbeDumpingThread-" + scriptDump.scriptType.name);
             t.start();
             dumpThreads.add(t);
         }
@@ -146,7 +147,8 @@ public class ProbeDump {
                     throw new RuntimeException(e);
                 }
             }
-        });
+        },
+        "ProbeDumpingThread-report");
         reportingThread.start();
     }
 

--- a/src/main/java/moe/wolfgirl/probejs/ProbeDumpingThread.java
+++ b/src/main/java/moe/wolfgirl/probejs/ProbeDumpingThread.java
@@ -1,0 +1,42 @@
+package moe.wolfgirl.probejs;
+
+import net.minecraft.network.chat.Component;
+
+import java.util.function.Consumer;
+
+/**
+ * @author ZZZank
+ */
+public class ProbeDumpingThread extends Thread {
+
+    public static ProbeDumpingThread INSTANCE;
+
+    public static boolean exists() {
+        return INSTANCE != null && INSTANCE.isAlive();
+    }
+
+    static ProbeDumpingThread create(final Consumer<Component> messageSender) {
+        if (exists()) {
+            throw new IllegalStateException("There's already a thread running");
+        }
+        ProbeDumpingThread thread = new ProbeDumpingThread(messageSender);
+        INSTANCE = thread;
+        return thread;
+    }
+
+    private ProbeDumpingThread(final Consumer<Component> messageSender) {
+        super(
+            () -> {  // Don't stall the client
+                var dump = new ProbeDump();
+                dump.defaultScripts();
+                try {
+                    dump.trigger(messageSender);
+                } catch (Throwable e) {
+                    GameUtils.logException(e);
+                    throw new RuntimeException(e);
+                }
+            },
+            "ProbeDumpingThread"
+        );
+    }
+}

--- a/src/main/java/moe/wolfgirl/probejs/ProbeDumpingThread.java
+++ b/src/main/java/moe/wolfgirl/probejs/ProbeDumpingThread.java
@@ -4,6 +4,8 @@ import net.minecraft.network.chat.Component;
 
 import java.util.function.Consumer;
 
+import moe.wolfgirl.probejs.utils.GameUtils;
+
 /**
  * @author ZZZank
  */

--- a/src/main/resources/assets/probejs/lang/en_us.json
+++ b/src/main/resources/assets/probejs/lang/en_us.json
@@ -1,4 +1,5 @@
 {
+    "probejs.already_running": "There's already a dumping thread running, please wait.",
     "probejs.dump.start": "ProbeJS dump started.",
     "probejs.dump.snippets_generated": "Snippets for VSCode generated.",
     "probejs.dump.mod_changed": "Mod environment changed.",


### PR DESCRIPTION
This PR:
-  Adds name for threads created by ProbeJS, which will be useful for debug.
-  Adds a new class `ProbeDumpingThread` to handle the creation of dumping threads, and guard against creating multiple dumping threads.
- There's also a new lang entry, used when users call `/probejs dump` command even though a dumping thread si already running. 