### PR TITLE
Mark ProbeJS number types as valid JS number type

### DIFF
--- a/src/main/java/moe/wolfgirl/probejs/docs/Primitives.java
+++ b/src/main/java/moe/wolfgirl/probejs/docs/Primitives.java
@@ -6,6 +6,7 @@ import moe.wolfgirl.probejs.plugin.ProbeJSPlugin;
 import moe.wolfgirl.probejs.lang.transpiler.TypeConverter;
 import moe.wolfgirl.probejs.lang.typescript.Declaration;
 import moe.wolfgirl.probejs.lang.typescript.code.Code;
+import moe.wolfgirl.probejs.lang.typescript.code.member.TypeDecl;
 import moe.wolfgirl.probejs.lang.typescript.code.type.js.JSPrimitiveType;
 import moe.wolfgirl.probejs.lang.typescript.code.type.Types;
 
@@ -22,6 +23,8 @@ public class Primitives extends ProbeJSPlugin {
     public static final JSPrimitiveType CHARACTER = Types.primitive("character");
     public static final JSPrimitiveType CHAR_SEQUENCE = Types.primitive("charseq");
 
+    private static final JSPrimitiveType TS_NUMBER = Types.primitive("Number");
+    private static final JSPrimitiveType JS_NUMBER = Types.primitive("number");
 
     static class JavaPrimitive extends Code {
         private final String javaPrimitive;
@@ -79,13 +82,17 @@ public class Primitives extends ProbeJSPlugin {
 
     @Override
     public void addGlobals(ScriptDump scriptDump) {
+        var numberBoth = Types.and(JS_NUMBER, TS_NUMBER);
         scriptDump.addGlobal("primitives",
-                JavaPrimitive.of("long", "Number"),
-                JavaPrimitive.of("integer", "Number"),
-                JavaPrimitive.of("short", "Number"),
-                JavaPrimitive.of("byte", "Number"),
-                JavaPrimitive.of("double", "Number"),
-                JavaPrimitive.of("float", "Number"),
+                //for number types, we can safely mark them as a primitive type instead of an interface
+                //because the classes that represent them are `final`, so there's no need of taking inheritance into account
+                new TypeDecl("long", numberBoth),
+                new TypeDecl("integer", numberBoth),
+                new TypeDecl("short", numberBoth),
+                new TypeDecl("byte", numberBoth),
+                new TypeDecl("double", numberBoth),
+                new TypeDecl("float", numberBoth),
+                //for CharSequence, we should NOT mark it as a primitive type, because of inheritance
                 JavaPrimitive.of("character", "String"),
                 JavaPrimitive.of("charseq", "String")
         );


### PR DESCRIPTION
The problem of current type declaration is that in `.js` files, number literals like `123` are treated as JS numbers, while types declared by ProbeJS like `integer` are inherting from TS number types. This will yield an error when typechecking is enabled.

before:
<img width="299" alt="before" src="https://github.com/user-attachments/assets/1c3fb6b2-a513-4ac1-8dc7-7c666155c258">

after:
<img width="333" alt="after" src="https://github.com/user-attachments/assets/5a0a6526-0668-4721-8ffc-6098f6cd04ba">

---

Cherry-picked from https://github.com/ZZZank/ProbeJS-Legacy/commit/6cc81f298063033e62fb115ccd69363d67ede275