### PR TITLE
context-aware JSLambdaType formatting

### DIFF
--- a/src/main/java/moe/wolfgirl/probejs/docs/events/RecipeEvents.java
+++ b/src/main/java/moe/wolfgirl/probejs/docs/events/RecipeEvents.java
@@ -152,7 +152,7 @@ public class RecipeEvents extends ProbeJSPlugin {
 
     private static JSLambdaType generateSchemaFunction(ClassPath returnType, RecipeSchema schema, TypeConverter converter) {
         JSLambdaType.Builder builder = Types.lambda()
-                .method()
+                .methodTypeStyle()
                 .returnType(Types.type(returnType));
 
         for (RecipeKey<?> key : schema.keys) {

--- a/src/main/java/moe/wolfgirl/probejs/lang/typescript/code/member/ParamDecl.java
+++ b/src/main/java/moe/wolfgirl/probejs/lang/typescript/code/member/ParamDecl.java
@@ -2,6 +2,7 @@ package moe.wolfgirl.probejs.lang.typescript.code.member;
 
 import moe.wolfgirl.probejs.lang.typescript.Declaration;
 import moe.wolfgirl.probejs.lang.typescript.code.type.BaseType;
+import moe.wolfgirl.probejs.lang.typescript.code.type.BaseType.FormatType;
 import moe.wolfgirl.probejs.utils.NameUtils;
 
 import java.util.ArrayList;
@@ -23,22 +24,30 @@ public final class ParamDecl {
     }
 
     public String format(int index, Declaration declaration) {
+        return format(index, declaration, BaseType.FormatType.INPUT);
+    }
+
+    public String format(int index, Declaration declaration, FormatType formatType) {
         String result = NameUtils.isNameSafe(name) ? name : "arg%d".formatted(index);
         if (varArg) result = "...%s".formatted(result);
         return "%s%s: %s".formatted(
                 result,
                 optional ? "?" : "",
-                type.line(declaration, BaseType.FormatType.INPUT)
+                type.line(declaration, formatType)
         );
     }
 
     public static String formatParams(List<ParamDecl> params, Declaration declaration) {
+        return formatParams(params, declaration, FormatType.INPUT);
+    }
+
+    public static String formatParams(List<ParamDecl> params, Declaration declaration, FormatType formatType) {
         List<String> formattedParams = new ArrayList<>();
         ListIterator<ParamDecl> it = params.listIterator();
         while (it.hasNext()) {
             int index = it.nextIndex();
             ParamDecl param = it.next();
-            formattedParams.add(param.format(index, declaration));
+            formattedParams.add(param.format(index, declaration, formatType));
         }
         return "(%s)".formatted(String.join(", ", formattedParams));
     }

--- a/src/main/java/moe/wolfgirl/probejs/lang/typescript/code/type/js/JSLambdaType.java
+++ b/src/main/java/moe/wolfgirl/probejs/lang/typescript/code/type/js/JSLambdaType.java
@@ -56,7 +56,7 @@ public class JSLambdaType extends BaseType {
 
         public Builder returnType(BaseType type) {
             if (forceFormatType != null) {
-                type = Types.ignoreContext(type, forceFormatType);
+                type = Types.ignoreContext(type, forceFormatType == FormatType.INPUT ? FormatType.RETURN : FormatType.INPUT);
             }
             this.returnType = type;
             return this;


### PR DESCRIPTION
This PR:
- makes formatting of parameters accept `FormatType` to determine its type formatting, with FormatType-less overloads for backward compat
- makes `JSLambdaType` context aware, which means its type foramtting will behave differently when provided `FormatType` is different.
    - e.g. For a lambda defined by `(a: A) => A`, when it's a param type, it will be formatted as `(a: A) => A$$Type`, and when it is a return type, it will be formatted as `(a: A$$Type) => A`

related: #92 
cherry-packed from: https://github.com/ZZZank/ProbeJS-Legacy/commit/2c3bd1db8da83bf5006a575fbfdd6bf06caf50e5 , https://github.com/ZZZank/ProbeJS-Legacy/commit/e49fd56e458eb8adb142c7f82938372e145ed130 , and https://github.com/ZZZank/ProbeJS-Legacy/commit/f1ff8703d86d31b77bf5048a8df3aac874bd9bbc