### PR TITLE
Only write "diff" instead of full ClassPath to class cache file

### DIFF
--- a/src/main/java/moe/wolfgirl/probejs/lang/java/ClassRegistry.java
+++ b/src/main/java/moe/wolfgirl/probejs/lang/java/ClassRegistry.java
@@ -166,24 +166,31 @@ public class ClassRegistry {
 
     public void writeTo(Path path) throws IOException {
         try (var writer = Files.newBufferedWriter(path)) {
-            for (Map.Entry<ClassPath, Clazz> entry : foundClasses.entrySet()) {
+            var lastPath = ClassPath.EMPTY;
+            for (Map.Entry<ClassPath, Clazz> entry : new TreeMap<>(foundClasses).entrySet()) {
+                var classPath = entry.getKey();
                 writer.write("%s\t%s\n".formatted(
-                        entry.getKey().getClassPathJava(),
+                        classPath.toDiff(lastPath),
                         entry.getValue().recursionDepth
                 ));
+                lastPath = classPath;
             }
         }
     }
 
     public void loadFrom(Path path) {
         try (var reader = Files.newBufferedReader(path)) {
+            var lastPath = ClassPath.EMPTY;
             for (String parts : (Iterable<String>) reader.lines()::iterator) {
+                ClassPath classPath = lastPath;
                 try {
                     String[] classRecursion = parts.split("\t");
-                    Class<?> loaded = Class.forName(classRecursion[0]);
+                    classPath = lastPath.fromDiff(classRecursion[0]);
+                    Class<?> loaded = classPath.forName();
                     fromClasses(Collections.singleton(loaded), Integer.parseInt(classRecursion[1]));
                 } catch (Throwable ignored) {
                 }
+                lastPath = classPath;
             }
         } catch (Exception ignored) {
         }

--- a/src/main/java/moe/wolfgirl/probejs/lang/java/clazz/ClassPath.java
+++ b/src/main/java/moe/wolfgirl/probejs/lang/java/clazz/ClassPath.java
@@ -8,9 +8,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public record ClassPath(List<String> parts) {
+    public static final ClassPath EMPTY = new ClassPath(List.of());
+
     private static List<String> transformJavaClass(Class<?> clazz) {
         String name = clazz.getName();
         String[] parts = name.split("\\.");
@@ -88,5 +92,38 @@ public record ClassPath(List<String> parts) {
     public String getFileKey() {
         if (parts.size() == 1) return getClassPath();
         return String.join(".", parts.subList(0, Math.min(4, parts.size() - 1)));
+    }
+
+    public String toDiff(ClassPath base) {
+        var common = countCommonPrefix(this.parts, base.parts);
+        var diff = new ArrayList<>(this.parts);
+        Collections.fill(diff.subList(0, common), "");
+        return String.join(".", diff);
+    }
+
+    public ClassPath fromDiff(String diff) {
+        var parts = diff.split("\\.");
+        for (int i = 0; i < parts.length; i++) {
+            if (parts[i].isEmpty()) {
+                parts[i] = this.parts.get(i);
+            } else {
+                break;
+            }
+        }
+        return new ClassPath(List.of(parts));
+    }
+
+    private static <T> int countCommonPrefix(List<T> a, List<T> b) {
+        var sizeCompare = Integer.min(a.size(), b.size());
+
+        var common = 0;
+        for (int i = 0; i < sizeCompare; i++) {
+            if (Objects.equals(a.get(i), b.get(i))) {
+                common++;
+            } else {
+                break;
+            }
+        }
+        return common;
     }
 }

--- a/src/main/java/moe/wolfgirl/probejs/lang/java/clazz/ClassPath.java
+++ b/src/main/java/moe/wolfgirl/probejs/lang/java/clazz/ClassPath.java
@@ -12,7 +12,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-public record ClassPath(List<String> parts) {
+public record ClassPath(List<String> parts) implements Comparable<ClassPath> {
     public static final ClassPath EMPTY = new ClassPath(List.of());
 
     private static List<String> transformJavaClass(Class<?> clazz) {
@@ -125,5 +125,21 @@ public record ClassPath(List<String> parts) {
             }
         }
         return common;
+    }
+
+    @Override
+    public int compareTo(ClassPath o) {
+        var a = this.parts;
+        var b = o.parts;
+
+        int sizeCompare = Integer.min(a.size(), b.size());
+        for (int i = 0; i < sizeCompare; i++) {
+            int compared = a.get(i).compareTo(b.get(i));
+            if (compared != 0) {
+                return compared;
+            }
+        }
+
+        return a.size() - b.size();
     }
 }


### PR DESCRIPTION
This can greatly reduce the size of `.probe/classes.txt`. Example:

```
com.electronwill.nightconfig.core.CommentedConfig	3
....CommentedConfig$Entry	4
....Config	4
....Config$Entry	5
....ConfigFormat	4
....EnumGetMethod	4
....UnmodifiableCommentedConfig	3
```

Dots at the starting of ClassPath means the number of common package parts this ClassPath shares with the previous ClassPath:

```
com.electronwill.nightconfig.core.CommentedConfig
   .            .           .    .CommentedConfig$Entry
   .            .           .    .Config
```

The implementation is fully backward-compatible, class cache using old format can still be parsed